### PR TITLE
Docs: Correct typo in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ body=$(jq --arg title "$ISSUE_TITLE" --arg link "$ISSUE_URL" '. + {
 
   ```
   · close, closes, closed
-  - fix, fixes, fixed
-  - resolve, resolves, resolved
-  - complete, completes, completed, completing
-  - ref, references
-  - part of
-  - related to
-  - contributes to
-  - towards
+  · fix, fixes, fixed
+  · resolve, resolves, resolved
+  · complete, completes, completed, completing
+  · ref, references
+  · part of
+  · related to
+  · contributes to
+  · towards
   ```
 
 <br />


### PR DESCRIPTION
## 작업 개요

> README 오타 수정

<br />

## 상세 내용

- [x] 목록 요소 구분 마커 변경 (**`-`** → **`·`**)